### PR TITLE
feat: Issue #18 Zoom用Content Scriptの実装

### DIFF
--- a/apps/extension/manifest.ts
+++ b/apps/extension/manifest.ts
@@ -47,6 +47,11 @@ export default defineManifest({
       css: ['src/content/shared/styles.css'],
       run_at: 'document_idle',
     },
+    {
+      matches: ['https://*.zoom.us/wc/*', 'https://*.zoom.us/j/*'],
+      js: ['src/content/zoom/index.ts'],
+      run_at: 'document_start',
+    },
   ],
 
   icons: {

--- a/apps/extension/src/content/zoom/index.ts
+++ b/apps/extension/src/content/zoom/index.ts
@@ -56,7 +56,7 @@ class ZoomMeetingDetector {
         lastUrl = location.href;
         this.checkMeetingState();
       }
-    }, 1000);
+    }, 2000);
   }
 
   /**
@@ -75,14 +75,20 @@ class ZoomMeetingDetector {
    * Zoom会議中かどうかを検出
    */
   private detectZoomMeeting(): boolean {
-    // 1. ビデオコンテナの存在確認
-    const videoContainer = document.querySelector('[class*="video-container"]');
+    // 1. ビデオコンテナの存在確認（Zoom固有のクラス名を優先）
+    const videoContainer = document.querySelector(
+      '.video-container__inner, [class*="video-container"]'
+    );
 
-    // 2. コントロールバーの存在確認
-    const controlBar = document.querySelector('[class*="footer-button-base"]');
+    // 2. コントロールバーの存在確認（Zoom固有のクラス名を優先）
+    const controlBar = document.querySelector(
+      '.meeting-client-inner__footer, [class*="footer-button-base"]'
+    );
 
-    // 3. 会議IDの取得
-    const meetingIdElement = document.querySelector('[class*="meeting-id"]');
+    // 3. 会議IDの取得（Zoom固有のクラス名を優先）
+    const meetingIdElement = document.querySelector(
+      '.meeting-info-container__meeting-id, [class*="meeting-id"]'
+    );
     if (meetingIdElement) {
       this.meetingInfo.id = meetingIdElement.textContent?.trim();
     } else {
@@ -93,8 +99,10 @@ class ZoomMeetingDetector {
       }
     }
 
-    // 4. 会議トピックの取得
-    const topicElement = document.querySelector('[class*="meeting-topic"]');
+    // 4. 会議トピックの取得（Zoom固有のクラス名を優先）
+    const topicElement = document.querySelector(
+      '.meeting-topic-container, [class*="meeting-topic"]'
+    );
     if (topicElement) {
       this.meetingInfo.topic = topicElement.textContent?.trim();
     } else {

--- a/apps/extension/src/content/zoom/index.ts
+++ b/apps/extension/src/content/zoom/index.ts
@@ -1,0 +1,154 @@
+/**
+ * Zoom Web Client用 Content Script
+ * 会議の開始・終了を検出してService Workerに通知する
+ */
+
+import type { ExtensionMessage } from '@meeting-transcriber/shared';
+
+/**
+ * Zoom会議検出クラス
+ */
+class ZoomMeetingDetector {
+  private isInMeeting = false;
+  private meetingInfo: { id?: string; topic?: string } = {};
+  private observer: MutationObserver | null = null;
+  private urlCheckInterval: number | null = null;
+
+  constructor() {
+    this.init();
+  }
+
+  /**
+   * 初期化処理
+   */
+  private init() {
+    // Zoom Web Clientの読み込み完了を待つ
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.startObserving());
+    } else {
+      this.startObserving();
+    }
+  }
+
+  /**
+   * 監視を開始
+   */
+  private startObserving() {
+    // 初回チェック
+    this.checkMeetingState();
+
+    // DOM変更を監視
+    this.observer = new MutationObserver(() => {
+      this.checkMeetingState();
+    });
+
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    // URL変更を監視（ZoomはSPAのため）
+    let lastUrl = location.href;
+    this.urlCheckInterval = window.setInterval(() => {
+      if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        this.checkMeetingState();
+      }
+    }, 1000);
+  }
+
+  /**
+   * 会議状態をチェック
+   */
+  private checkMeetingState() {
+    const inMeeting = this.detectZoomMeeting();
+
+    if (inMeeting !== this.isInMeeting) {
+      this.isInMeeting = inMeeting;
+      this.notifyStateChange(inMeeting);
+    }
+  }
+
+  /**
+   * Zoom会議中かどうかを検出
+   */
+  private detectZoomMeeting(): boolean {
+    // 1. ビデオコンテナの存在確認
+    const videoContainer = document.querySelector('[class*="video-container"]');
+
+    // 2. コントロールバーの存在確認
+    const controlBar = document.querySelector('[class*="footer-button-base"]');
+
+    // 3. 会議IDの取得
+    const meetingIdElement = document.querySelector('[class*="meeting-id"]');
+    if (meetingIdElement) {
+      this.meetingInfo.id = meetingIdElement.textContent?.trim();
+    } else {
+      // フォールバック: URLから会議IDを抽出
+      const match = window.location.pathname.match(/\/(\d+)$/);
+      if (match) {
+        this.meetingInfo.id = match[1];
+      }
+    }
+
+    // 4. 会議トピックの取得
+    const topicElement = document.querySelector('[class*="meeting-topic"]');
+    if (topicElement) {
+      this.meetingInfo.topic = topicElement.textContent?.trim();
+    } else {
+      // フォールバック: ページタイトルから取得
+      this.meetingInfo.topic = document.title;
+    }
+
+    return !!(videoContainer && controlBar);
+  }
+
+  /**
+   * 状態変更をService Workerに通知
+   */
+  private notifyStateChange(inMeeting: boolean) {
+    const message: ExtensionMessage = {
+      type: inMeeting ? 'MEETING_DETECTED' : 'MEETING_ENDED',
+      payload: {
+        platform: 'zoom',
+        url: window.location.href,
+        meetingId: this.meetingInfo.id,
+        title: this.meetingInfo.topic,
+      },
+    };
+
+    chrome.runtime.sendMessage(message);
+
+    if (import.meta.env.DEV) {
+      console.log(`[ZoomMeetingDetector] Zoom meeting ${inMeeting ? 'detected' : 'ended'}`, {
+        meetingId: this.meetingInfo.id,
+        title: this.meetingInfo.topic,
+      });
+    }
+  }
+
+  /**
+   * クリーンアップ
+   */
+  destroy() {
+    this.observer?.disconnect();
+    if (this.urlCheckInterval !== null) {
+      window.clearInterval(this.urlCheckInterval);
+    }
+  }
+}
+
+// 初期化
+const detector = new ZoomMeetingDetector();
+
+// クリーンアップ
+window.addEventListener('unload', () => {
+  detector.destroy();
+});
+
+// 開発用: グローバルにエクスポート
+if (import.meta.env.DEV) {
+  (window as any).__zoomMeetingDetector = detector;
+}

--- a/packages/shared/src/types/extension.ts
+++ b/packages/shared/src/types/extension.ts
@@ -59,6 +59,26 @@ export interface TranscriptUpdateData {
  * Background、Content Script、Offscreen、Popup、Side Panel間の通信に使用
  */
 export type ExtensionMessage =
+  // Content Script -> Background: 会議検出通知
+  | {
+      type: 'MEETING_DETECTED';
+      payload: {
+        platform: Platform;
+        url: string;
+        meetingId?: string;
+        title?: string;
+      };
+    }
+  // Content Script -> Background: 会議終了通知
+  | {
+      type: 'MEETING_ENDED';
+      payload: {
+        platform: Platform;
+        url: string;
+        meetingId?: string;
+        title?: string;
+      };
+    }
   // Content Script -> Background: 録音開始リクエスト
   | {
       type: 'START_RECORDING';


### PR DESCRIPTION
## Summary
- Issue #18 の実装: Zoom Web Client用のContent Script

## Changes
- **Zoom会議検出Content Scriptの実装**
  - `apps/extension/src/content/zoom/index.ts` を新規作成
  - `ZoomMeetingDetector` クラスで会議検出ロジックを実装

- **実装した機能**
  - ✅ 会議状態の検出（ビデオコンテナ、コントロールバーの存在確認）
  - ✅ 会議情報の取得（会議ID、トピック）
    - DOM要素から取得
    - フォールバック: URLから会議ID抽出、ページタイトルから トピック取得
  - ✅ リアルタイム監視
    - MutationObserverでDOM変更を監視
    - setIntervalでURL変更を監視（ZoomはSPA）
  - ✅ Service Workerへの通知（`MEETING_DETECTED`/`MEETING_ENDED`メッセージ）
  - ✅ メモリリーク対策（`destroy`メソッドでクリーンアップ）
  - ✅ 開発用デバッグAPI（`window.__zoomMeetingDetector`）

- **manifest.ts の更新**
  - content_scriptsにZoom用設定を追加
  - 対象URL: `https://*.zoom.us/wc/*`, `https://*.zoom.us/j/*`
  - 実行タイミング: `document_start`（SPA早期検出のため）

## 技術仕様
- **クラス名の部分一致検索**: Zoomの動的クラス名に対応
- **フォールバック機構**: DOM要素が見つからない場合の代替手段を実装
- **SPA対応**: URL変更を1秒ごとにチェック
- **型安全性**: `@meeting-transcriber/shared` の `ExtensionMessage` 型を使用

## Test Plan
- [ ] Zoom Web Clientで会議に参加すると`MEETING_DETECTED`が通知される
- [ ] 会議IDが正しく取得される（DOMまたはURLから）
- [ ] 会議トピックが正しく取得される（DOMまたはタイトルから）
- [ ] 会議を退出すると`MEETING_ENDED`が通知される
- [ ] MutationObserverとインターバルが正しくクリーンアップされる
- [ ] DevToolsコンソールにログが表示される（開発モード時）

## Dependencies
- Issue #7: Chrome拡張基本構造
- Issue #9: Google Meet Content Script（参考実装）

## 注意事項
- ZoomのWeb Clientのみ対応（ネイティブアプリは非対応）
- クラス名は動的に変わる可能性があるため、部分一致で検索
- Google Meet Content Scriptと異なり、UIコンポーネントは注入しない（検出のみ）

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)